### PR TITLE
[ACC-27] Return a 404 status in non-hex IDs

### DIFF
--- a/src/main/java/org/accounting/system/validators/MetricDefinitionNotFoundValidator.java
+++ b/src/main/java/org/accounting/system/validators/MetricDefinitionNotFoundValidator.java
@@ -2,8 +2,8 @@ package org.accounting.system.validators;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.internal.StringUtil;
+import io.vavr.control.Try;
 import org.accounting.system.constraints.MetricDefinitionNotFound;
-import org.accounting.system.entities.MetricDefinition;
 import org.accounting.system.exceptions.CustomValidationException;
 import org.accounting.system.services.MetricDefinitionService;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import javax.enterprise.inject.spi.CDI;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.util.Optional;
 
 /**
  * This {@link MetricDefinitionNotFoundValidator} defines the logic to validate the {@link MetricDefinitionNotFound}.
@@ -42,9 +41,9 @@ public class MetricDefinitionNotFoundValidator implements ConstraintValidator<Me
 
         MetricDefinitionService metricDefinitionService = CDI.current().select(MetricDefinitionService.class).get();
 
-        Optional<MetricDefinition> metricDefinition = metricDefinitionService.findById(value);
-
-        metricDefinition.orElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND));
+        Try
+                .run(()->metricDefinitionService.findById(value).orElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND)))
+                .getOrElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND));
 
         return true;
     }

--- a/src/main/java/org/accounting/system/validators/MetricNotFoundValidator.java
+++ b/src/main/java/org/accounting/system/validators/MetricNotFoundValidator.java
@@ -2,8 +2,8 @@ package org.accounting.system.validators;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.internal.StringUtil;
+import io.vavr.control.Try;
 import org.accounting.system.constraints.MetricNotFound;
-import org.accounting.system.entities.Metric;
 import org.accounting.system.exceptions.CustomValidationException;
 import org.accounting.system.services.MetricService;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import javax.enterprise.inject.spi.CDI;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.util.Optional;
 
 /**
  * This {@link MetricNotFoundValidator} defines the logic to validate the {@link MetricNotFound}.
@@ -42,9 +41,9 @@ public class MetricNotFoundValidator implements ConstraintValidator<MetricNotFou
 
         MetricService metricService = CDI.current().select(MetricService.class).get();
 
-        Optional<Metric> metric = metricService.findById(value);
-
-        metric.orElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND));
+        Try
+                .run(()->metricService.findById(value).orElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND)))
+                .getOrElseThrow(()->new CustomValidationException(builder.toString(), HttpResponseStatus.NOT_FOUND));
 
         return true;
     }

--- a/src/test/java/org/accounting/system/MetricDefinitionEndpointTest.java
+++ b/src/test/java/org/accounting/system/MetricDefinitionEndpointTest.java
@@ -262,6 +262,21 @@ public class MetricDefinitionEndpointTest {
     }
 
     @Test
+    public void update_metric_definition_not_found() {
+
+        var response = given()
+                .contentType(ContentType.JSON)
+                .patch("/{id}", "556787878e-rrr")
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("There is no Metric Definition with the following id: 556787878e-rrr", response.message);
+    }
+
+    @Test
     public void update_metric_definition_full() {
 
         Mockito.when(readPredefinedTypesService.searchForUnitType(any())).thenReturn(Optional.of("SECOND"));
@@ -472,17 +487,17 @@ public class MetricDefinitionEndpointTest {
     }
 
     @Test
-    public void fetch_metric_definition_internal_server_error() {
+    public void fetch_metric_definition_not_found_non_hex_id() {
 
         var response = given()
                 .get("/{id}", "iiejijirj33i3i")
                 .then()
                 .assertThat()
-                .statusCode(500)
+                .statusCode(404)
                 .extract()
                 .as(InformativeResponse.class);
 
-        assertEquals(500, response.code);
+        assertEquals(404, response.code);
     }
 
     @Test
@@ -618,6 +633,21 @@ public class MetricDefinitionEndpointTest {
     }
 
     @Test
+    public void fetch_metric_definition_pagination_non_hex_id() {
+
+        var response = given()
+                .queryParam("page", 0)
+                .get("/{metric_definition_id}/metrics", "ijidij3d333")
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("There is no Metric Definition with the following id: ijidij3d333", response.message);
+    }
+
+    @Test
     public void fetch_all_metric_definitions() {
 
         Mockito.when(readPredefinedTypesService.searchForUnitType(any())).thenReturn(Optional.of("SECOND"));
@@ -648,6 +678,22 @@ public class MetricDefinitionEndpointTest {
                 .assertThat()
                 .body("size()", is(2));
     }
+
+    @Test
+    public void delete_metric_definition_not_found() {
+
+
+        var response = given()
+                .delete("/{metric_definition_id}", "7dyebdheb7377e")
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("There is no Metric Definition with the following id: 7dyebdheb7377e", response.message);
+    }
+
 
     @Test
     public void delete_metric_definition_prohibited() {


### PR DESCRIPTION
The API return a 404 HTTP status when MongoDB parses a non-hex metric_definition_id or metric_id.

ACC-27