### PR TITLE
[ACC-28] Location in API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Before running the _über-jar_, you have to export the following variables:
 - export `QUARKUS_MONGODB_CONNECTION_STRING=mongodb://{host}:{port}`
 - export `UNIT_TYPES_FILE={filesystem path to unit_type.conf}`
 - export `METRIC_TYPES_FILE={filesystem path to metric_type.conf}`
+- export `SERVER_URL={The proxy server URL that acts on behalf of the Accounting System}`
 
 Once the variables above have been exported, you should execute the following command:
 `java -jar *-runner.jar`

--- a/src/main/java/org/accounting/system/endpoints/MetricEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/MetricEndpoint.java
@@ -7,6 +7,7 @@ import org.accounting.system.dtos.MetricRequestDto;
 import org.accounting.system.dtos.MetricResponseDto;
 import org.accounting.system.dtos.UpdateMetricRequestDto;
 import org.accounting.system.services.MetricService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -14,6 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -33,6 +35,12 @@ import javax.ws.rs.core.UriInfo;
 
 @Path("/metrics")
 public class MetricEndpoint {
+
+    @ConfigProperty(name = "quarkus.resteasy.path")
+    String basePath;
+
+    @ConfigProperty(name = "server.url")
+    String serverUrl;
 
     @Inject
     private MetricService metricService;
@@ -91,7 +99,9 @@ public class MetricEndpoint {
 
         MetricResponseDto response = metricService.save(metricRequestDto);
 
-        return Response.created(uriInfo.getAbsolutePathBuilder().path(response.id).build()).entity(response).build();
+        UriInfo serverInfo = new ResteasyUriInfo(serverUrl.concat(basePath).concat(uriInfo.getPath()), basePath);
+
+        return Response.created(serverInfo.getAbsolutePathBuilder().path(response.id).build()).entity(response).build();
     }
 
     @Tag(name = "Metric")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,6 @@ metric.types.file = /etc/accounting-system/conf.d/metric_type.conf
 
 # Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after the entry’s creation, the most recent replacement of its value, or its last read.
 quarkus.cache.caffeine."types-to-json".expire-after-access=24H
+
+# The proxy server URL that acts on behalf of the Accounting System
+server.url=${SERVER_URL:http://localhost:8080}


### PR DESCRIPTION
There is a proxy server acting on behalf of the Accounting System. There are also many API responses containing the location of the created resources. As a result, this location should encapsulate the proxy server URL.
To tackle that, we have to export a variable named SERVER_URL, which contains the proxy server URL.
The application reads the variable and incorporates it into every location.

ACC-28