### PR TITLE
[ACC-38] Disable OIDC Authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,25 +6,25 @@
   <artifactId>accounting-system</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
+    <apache.common3.version>3.12.0</apache.common3.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <json.simple.version>1.1.1</json.simple.version>
+    <junit.vintage.engine.vesrion>5.7.0</junit.vintage.engine.vesrion>
+    <lombok.version>1.18.22</lombok.version>
+    <mapstruct.version>1.4.2.Final</mapstruct.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <mockito.core.version>4.2.0</mockito.core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <quarkus.liquibase.mongo.version>2.6.2.Final</quarkus.liquibase.mongo.version>
+    <quarkus.mockito.version>2.6.2.Final</quarkus.mockito.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.6.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <lombok.version>1.18.22</lombok.version>
-    <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <quarkus.liquibase.mongo.version>2.6.2.Final</quarkus.liquibase.mongo.version>
-    <apache.common3.version>3.12.0</apache.common3.version>
-    <json.simple.version>1.1.1</json.simple.version>
     <vavr.version>0.10.4</vavr.version>
-    <quarkus.mockito.version>2.6.2.Final</quarkus.mockito.version>
-    <mockito.core.version>4.2.0</mockito.core.version>
-    <junit.vintage.engine.vesrion>5.7.0</junit.vintage.engine.vesrion>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -73,6 +73,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-security</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -128,10 +132,10 @@
       <version>${mapstruct.version}</version>
     </dependency>
     <dependency>
-    <groupId>org.apache.commons</groupId>
-    <artifactId>commons-lang3</artifactId>
-    <version>${apache.common3.version}</version>
-   </dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${apache.common3.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-liquibase-mongodb</artifactId>

--- a/src/main/java/org/accounting/system/DisabledAuthController.java
+++ b/src/main/java/org/accounting/system/DisabledAuthController.java
@@ -1,0 +1,22 @@
+package org.accounting.system;
+
+import io.quarkus.security.spi.runtime.AuthorizationController;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+
+@Alternative
+@Priority(Interceptor.Priority.LIBRARY_AFTER)
+@ApplicationScoped
+public class DisabledAuthController extends AuthorizationController {
+    @ConfigProperty(name = "disable.authorization", defaultValue = "false")
+    boolean disableAuthorization;
+
+    @Override
+    public boolean isAuthorizationEnabled() {
+        return !disableAuthorization;
+    }
+}

--- a/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
@@ -1,6 +1,5 @@
 package org.accounting.system.endpoints;
 
-import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.security.Authenticated;
 import org.accounting.system.constraints.MetricDefinitionNotFound;
 import org.accounting.system.dtos.InformativeResponse;
@@ -72,9 +71,6 @@ public class MetricDefinitionEndpoint {
 
     @Inject
     Predicates predicates;
-
-    @Inject
-    TokenIntrospection tokenIntrospection;
 
     public MetricDefinitionEndpoint(MetricDefinitionService metricDefinitionService, ReadPredefinedTypesService readPredefinedTypesService, Predicates predicates) {
         this.metricDefinitionService = metricDefinitionService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.resteasy.path=/accounting-system
 
-%prod.quarkus.mongodb.connection-string = mongodb://mongo1:27017,mongo2:27017,mongo3:27017
+%prod.quarkus.mongodb.connection-string = mongodb://localhost:27017
 
 quarkus.mongodb.database = accounting-system
 
@@ -55,3 +55,5 @@ quarkus.oidc.application-type=service
 keycloak.server.url=https://login-devel.einfra.grnet.gr/auth
 keycloak.server.realm=einfra
 keycloak.server.client.id=accounting-system-public
+
+disable.authorization=false


### PR DESCRIPTION
The disable.authorization property, which is responsible for disabling the OIDC authentication, has been added in application.properties.

By exporting that variable before the application deployment, the authentication process is disabled.