### PR TITLE
[ACC-49] Modify an existing Access Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,13 @@ To generate a role, we have to define the available API operations and access ty
 
 The available API operations are:
 
-| Operation   |  Description                                     |
-| ------------|------------------------------------------------  | 
-| Create      | Can create new entities within a collection      |
-| Update      | Can update existing entities within a collection |
-| Delete      | Can delete existing entities within a collection |
-| Read        | Can fetch existing entities within a collection  |
+| Operation   |  Description                                                                             |
+| ------------|----------------------------------------------------------------------------------------  | 
+| Create      | Can create new entities within a collection                                              |
+| Update      | Can update existing entities within a collection                                         |
+| Delete      | Can delete existing entities within a collection                                         |
+| Read        | Can fetch existing entities within a collection                                          |
+| Acl         | Can specify which services are granted access to particular entities within a collection |
 
 ### Access Types
 
@@ -188,22 +189,21 @@ The available Accounting System API collections are:
 
 Based on the above, we can generate some indicative roles:
 
-| Role                      | Create | Update | Delete  | Read   | Collections      |
-| ------------------------- |--------| -------| --------| -------| -----------------|
-| metric_definition_admin   | Always | Always | Always  | Always | MetricDefinition |
-| metric_inspector          |        |        |         | Always | Metric           |
-| metric_creator            | Always | Entity | Entity  | Entity | Metric           |
-| role_editor               | Always | Always | Never   | Always | Role             |
-| role_editor               | Always | Always | Never   | Always | Role             |
+| Role                      | Create | Update | Delete  | Read   | Acl    | Collection       |
+| ------------------------- |--------| -------| --------| -------| -------|------------------|
+| metric_definition_admin   | Always | Always | Always  | Always | Always | MetricDefinition |
+| metric_inspector          |        |        |         | Always |        | Metric           |
+| metric_creator            | Always | Entity | Entity  | Entity | Entity | Metric           |
+| role_editor               | Always | Always | Never   | Always |        | Role             |
 
 __Notes:__ 
 -   The role name should be unique.
 -   The blank value is converted to "Never" value
 
 Consequently:
--   __metric_definition_admin__ can create new Metric Definitions, as well as update, delete and read any entity in the collection. In other words, __metric_definition_admin__ will always be able to perform any operation in the Metric Definition collection.
+-   __metric_definition_admin__ can create new Metric Definitions, as well as update, delete and read any entity in the collection. Can also specify which services will be granted access to any entity within a Metric Collection. In other words, __metric_definition_admin__ will always be able to perform any operation in the Metric Definition collection.
 -   __metric_inspector__  can read any entity in the Metric collection, but cannot create new ones or update, delete any Metrics.
--   __metric_creator__ can create new Metrics, but can update, delete or read only its Metrics.
+-   __metric_creator__ can create new Metrics, but can update, delete or read only its Metrics. It can also specify which services will have access to the entities it has created. Finally, it can also manage Metrics that have been explicitly declared through the ACL process.
 -   __role_editor__ can create new Roles, as well as update, and read any entity in the Role collection but cannot delete any entity in it.
 
 ### Generating new Roles via Accounting System API
@@ -240,7 +240,11 @@ POST 'https://host/accounting-system/roles'
       {
         "operation" : "READ",
         "access_type" : "ALWAYS"
-      }
+      },
+      {
+        "operation" : "ACL",
+        "access_type" : "ALWAYS"
+      },
     ]
     },
   
@@ -291,6 +295,10 @@ POST 'https://host/accounting-system/roles'
       },
       {
         "operation" : "READ",
+        "access_type" : "ENTITY"
+      },
+      {
+        "operation" : "ACL",
         "access_type" : "ENTITY"
       }
     ]

--- a/src/main/java/org/accounting/system/constraints/StringEnumeration.java
+++ b/src/main/java/org/accounting/system/constraints/StringEnumeration.java
@@ -5,6 +5,7 @@ import org.accounting.system.validators.StringEnumerationValidator;
 import javax.validation.Constraint;
 import javax.validation.Payload;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -14,7 +15,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Documented
 @Constraint(validatedBy = StringEnumerationValidator.class)
-@Target({ FIELD, PARAMETER})
+@Target({ FIELD, PARAMETER, ElementType.TYPE_USE})
 @Retention(RUNTIME)
 public @interface StringEnumeration {
 

--- a/src/main/java/org/accounting/system/dtos/acl/AccessControlUpdateDto.java
+++ b/src/main/java/org/accounting/system/dtos/acl/AccessControlUpdateDto.java
@@ -10,25 +10,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import java.util.Set;
 
-@Schema(name="AccessControlRequest", description="An object represents a request for creating an Access Control Entry.")
-public class AccessControlRequestDto {
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "who is the id of a Service/User that the Access Control grants access.",
-            example = "fbdb4e4a-6e93-4b08-a1e7-0b7bd08520a6",
-            required = true
-    )
-    @JsonProperty("who")
-    @NotEmpty(message = "who may not be empty.")
-    public String who;
+@Schema(name="AccessControlUpdate", description="An object represents a request for updating an Access Control Entry.")
+public class AccessControlUpdateDto {
 
     @Schema(
             type = SchemaType.ARRAY,
             implementation = AccessControlPermission.class,
             required = true,
-            description = "This component is a set of permissions.",
+            description = "The set of permissions to be updated.",
             minItems = 1
     )
     @JsonProperty("permissions")

--- a/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
@@ -8,6 +8,7 @@ import org.accounting.system.dtos.MetricDefinitionResponseDto;
 import org.accounting.system.dtos.PageResource;
 import org.accounting.system.dtos.UpdateMetricDefinitionRequestDto;
 import org.accounting.system.dtos.acl.AccessControlRequestDto;
+import org.accounting.system.dtos.acl.AccessControlUpdateDto;
 import org.accounting.system.enums.Collection;
 import org.accounting.system.exceptions.UnprocessableException;
 import org.accounting.system.interceptors.annotations.Permission;
@@ -601,7 +602,7 @@ public class MetricDefinitionEndpoint {
                     implementation = InformativeResponse.class)))
     @APIResponse(
             responseCode = "404",
-            description = "There is no entity {entity} into the collection Metric Definition.",
+            description = "Metric Definition has not been found.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
@@ -638,14 +639,100 @@ public class MetricDefinitionEndpoint {
                                                 schema = @Schema(type = SchemaType.STRING))
                                         @PathParam("metric_definition_id")
                                         @Valid
-                                        @NotFoundEntity(repository = MetricDefinitionRepository.class, message = "There is no Metric Definition with the following id:") String metricDefinitionId,
-                                        @Context UriInfo uriInfo) {
+                                        @NotFoundEntity(repository = MetricDefinitionRepository.class, message = "There is no Metric Definition with the following id:") String metricDefinitionId) {
 
 
         metricDefinitionService.grantPermission(metricDefinitionId, accessControlRequestDto);
 
         var informativeResponse = new InformativeResponse();
         informativeResponse.message = "Access Control entry has been created successfully";
+        informativeResponse.code = 200;
+
+        return Response.ok().entity(informativeResponse).build();
+    }
+
+    @Tag(name = "Metric Definition")
+    @Operation(
+            summary = "Modify an existing Access Control Entry.",
+            description = "This endpoint is responsible for updating an existing Access Control Entry. It will modify a specific Access Control Entry " +
+                    "which has granted permissions on a Metric Definition to a specific service/user." +
+                    "You can update a part or all attributes of the Access Control entity.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Access Control entry has been updated successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Bad Request.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User/Service has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "The authenticated user/service is not permitted to perform the requested operation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Metric Definition has not been found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "There is an Access Control Entry with this {who, collection, entity}.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "415",
+            description = "Cannot consume content type.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Errors.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+
+    @PATCH
+    @Path("/{metric_definition_id}/acl/{who}")
+    @Produces(value = MediaType.APPLICATION_JSON)
+    @Consumes(value = MediaType.APPLICATION_JSON)
+    @Permission(collection = Collection.MetricDefinition, operation = org.accounting.system.enums.Operation.ACL)
+    public Response modifyAccessControl(@Valid @NotNull(message = "The request body is empty.") AccessControlUpdateDto accessControlUpdateDto,
+                                        @Parameter(
+                                                description = "metric_definition_id in which permissions have been granted.",
+                                                required = true,
+                                                example = "507f1f77bcf86cd799439011",
+                                                schema = @Schema(type = SchemaType.STRING))
+                                        @PathParam("metric_definition_id")
+                                        @Valid
+                                        @NotFoundEntity(repository = MetricDefinitionRepository.class, message = "There is no Metric Definition with the following id:") String metricDefinitionId,
+                                        @Parameter(
+                                                description = "who is the service/user to whom the permissions have been granted.",
+                                                required = true,
+                                                example = "fbdb4e4a-6e93-4b08-a1e7-0b7bd08520a6",
+                                                schema = @Schema(type = SchemaType.STRING))
+                                            @PathParam("who") String who) {
+
+
+        metricDefinitionService.modifyPermission(metricDefinitionId, who, accessControlUpdateDto);
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.message = "Access Control entry has been updated successfully.";
         informativeResponse.code = 200;
 
         return Response.ok().entity(informativeResponse).build();

--- a/src/main/java/org/accounting/system/mappers/AccessControlMapper.java
+++ b/src/main/java/org/accounting/system/mappers/AccessControlMapper.java
@@ -2,8 +2,11 @@ package org.accounting.system.mappers;
 
 import org.accounting.system.dtos.acl.AccessControlRequestDto;
 import org.accounting.system.dtos.acl.AccessControlResponseDto;
+import org.accounting.system.dtos.acl.AccessControlUpdateDto;
 import org.accounting.system.entities.acl.AccessControl;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -18,4 +21,9 @@ public interface AccessControlMapper {
     AccessControl requestToAccessControl(AccessControlRequestDto request);
 
     AccessControlResponseDto accessControlToResponse(AccessControl response);
+
+    @Mapping(target = "who", ignore = true)
+    @Mapping(target = "collection", ignore = true)
+    @Mapping(target = "entity", ignore = true)
+    void updateAccessControlFromDto(AccessControlUpdateDto dto, @MappingTarget AccessControl accessControl);
 }

--- a/src/main/java/org/accounting/system/repositories/acl/AccessControlRepository.java
+++ b/src/main/java/org/accounting/system/repositories/acl/AccessControlRepository.java
@@ -22,11 +22,11 @@ public class AccessControlRepository implements PanacheMongoRepository<AccessCon
     /**
      * Returns a specific Collection entity to which a service/user may has {permission} access.
      *
-     * @param who Owner id
+     * @param who the one to whom the permission may be granted
      * @param collection The name of the Collection
-     * @param entity Entity id
+     * @param entity entity id
      * @param permission access control permission
-     * @return The Access Control that grant access to a service/user in a particular entity
+     * @return the Access Control that may grant access to a service/user in a particular entity
      */
     public Optional<AccessControl> findByWhoAndCollectionAndEntityAndPermission(String who, Collection collection, String entity, AccessControlPermission permission){
 
@@ -35,13 +35,26 @@ public class AccessControlRepository implements PanacheMongoRepository<AccessCon
 
     /**
      * Returns all Collection entities to which a service/user has {permission} access
-     * @param who Owner id
-     * @param collection The name of the Collection
+     * @param who the one to whom the permissions have been granted
+     * @param collection the name of the Collection
      * @param permission access control permission
-     * @return The available access controls that grant access to a service/user in a Collection
+     * @return the available access controls that grant access to a service/user in a Collection
      */
     public List<AccessControl> findByWhoAndCollection(String who, Collection collection, AccessControlPermission permission){
 
         return list("who = ?1 and collection = ?2 and permissions in ?3", who, collection, permission);
+    }
+
+    /**
+     * Returns a specific Collection entity to which a service/user may has access.
+     *
+     * @param who the one to whom the permission may be granted
+     * @param collection The name of the Collection
+     * @param entity entity id
+     * @return the Access Control that may grant access to a service/user in a particular entity
+     */
+    public Optional<AccessControl> findByWhoAndCollectionAndEntity(String who, Collection collection, String entity){
+
+        return find("who = ?1 and collection = ?2 and entity = ?3", who, collection, entity).stream().findAny();
     }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
@@ -16,28 +16,38 @@ import java.util.List;
  */
 public abstract class AbstractModulator<E extends Entity> extends AccessModulator<E>{
 
+    @Override
     public  E fetchEntityById(ObjectId id){
         return get().fetchEntityById(id);
     }
 
+    @Override
     public  boolean deleteEntityById(ObjectId id){
         return get().deleteEntityById(id);
     }
 
+    @Override
     public E updateEntity(E entity){
         return get().updateEntity(entity);
     }
 
+    @Override
     public  List<E> getAllEntities(){
         return get().getAllEntities();
     }
 
+    @Override
     public void grantPermission(AccessControl accessControl){
         try{
             get().grantPermission(accessControl);
         } catch (MongoWriteException e){
             throw new ConflictException("There is already an Access Control Entry with this {who, collection, entity} : {" + accessControl.getWho()+", "+accessControl.getCollection()+", "+accessControl.getEntity()+"}");
         }
+    }
+
+    @Override
+    public void modifyPermission(AccessControl accessControl) {
+        get().modifyPermission(accessControl);
     }
 
     public abstract AccessAlwaysModulator always();

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
@@ -45,4 +45,9 @@ public abstract class AccessAlwaysModulator<E extends Entity> extends AccessModu
 
          getAccessControlRepository().persist(accessControl);
     }
+
+    @Override
+    public void modifyPermission(AccessControl accessControl) {
+        getAccessControlRepository().update(accessControl);
+    }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessControlModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessControlModulator.java
@@ -82,7 +82,13 @@ public abstract class AccessControlModulator<E extends Entity> extends AccessMod
     @Override
     public void grantPermission(AccessControl accessControl) {
 
-        throw new ForbiddenException("You have no access to grant acl permissions to this entity : " + accessControl.getEntity());
+        throw new ForbiddenException("You have no access to this entity : " + accessControl.getEntity());
+    }
+
+    @Override
+    public void modifyPermission(AccessControl accessControl) {
+
+        throw new ForbiddenException("You have no access to modify these permissions.");
     }
 
     private Optional<AccessControl> getAccessControl(ObjectId id, AccessControlPermission permission){

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessEntityModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessEntityModulator.java
@@ -72,6 +72,16 @@ public abstract class AccessEntityModulator<E extends Entity> extends AccessCont
         }
     }
 
+    @Override
+    public void modifyPermission(AccessControl accessControl) {
+
+        if (isIdentifiable(accessControl.getCreatorId())) {
+            getAccessControlRepository().update(accessControl);
+        } else {
+            super.modifyPermission(accessControl);
+        }
+    }
+
     /**
      * Checks if the given id can be identified by the subject of an access token.
      *

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
@@ -37,7 +37,17 @@ public abstract class AccessModulator<E extends Entity> implements PanacheMongoR
 
     public abstract List<E> getAllEntities();
 
+    /**
+     * This method is responsible fοr granting permissions to specific entity within a generic collection
+     * @param accessControl It essentially expresses the permissions that will be granted
+     */
     public abstract void grantPermission(AccessControl accessControl);
+
+    /**
+     * This method is responsible fοr updating an existing permissions which have already been granted to specific entity
+     * @param accessControl It essentially expresses the permissions that will be modified
+     */
+    public abstract void modifyPermission(AccessControl accessControl);
 
     public List<E> combineTwoLists(List<E> a, List<E> b){
 


### PR DESCRIPTION
You can modify an existing Access Control entry.

A mechanism has been created that allows the modification of Access Control entry. Only the Metric Definition mechanism
has been activated in this commit.

ACC-49