### PR TITLE
[ACC-50] Delete an existing Access Control

### DIFF
--- a/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/MetricDefinitionEndpoint.java
@@ -339,7 +339,7 @@ public class MetricDefinitionEndpoint {
                     implementation = InformativeResponse.class)))
     @APIResponse(
             responseCode = "401",
-            description = "User/Service has not been authenticated..",
+            description = "User/Service has not been authenticated.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
@@ -736,5 +736,71 @@ public class MetricDefinitionEndpoint {
         informativeResponse.code = 200;
 
         return Response.ok().entity(informativeResponse).build();
+    }
+
+    @Tag(name = "Metric Definition")
+    @Operation(
+            summary = "Deletes an existing Access Control entry.",
+            description = "You can delete the permissions that a service/user can access to manage a specific Metric Definition.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Access Control entry has been deleted successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User/Service has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "The authenticated user/service is not permitted to perform the requested operation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Metric Definition has not been found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.ARRAY,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Errors.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+
+    @DELETE()
+    @Path("/{metric_definition_id}/acl/{who}")
+    @Produces(value = MediaType.APPLICATION_JSON)
+    @Permission(collection = Collection.MetricDefinition, operation = org.accounting.system.enums.Operation.ACL)
+    public Response deleteAccessControl(@Parameter(
+            description = "metric_definition_id in which permissions have been granted.",
+            required = true,
+            example = "507f1f77bcf86cd799439011",
+            schema = @Schema(type = SchemaType.STRING))
+                                            @PathParam("metric_definition_id")
+                                            @Valid
+                                            @NotFoundEntity(repository = MetricDefinitionRepository.class, message = "There is no Metric Definition with the following id:") String metricDefinitionId,
+                                        @Parameter(
+                                                description = "who is the service/user to whom the permissions have been granted.",
+                                                required = true,
+                                                example = "fbdb4e4a-6e93-4b08-a1e7-0b7bd08520a6",
+                                                schema = @Schema(type = SchemaType.STRING))
+                                            @PathParam("who") String who) {
+
+
+        metricDefinitionService.deletePermission(metricDefinitionId, who);
+
+        var successResponse = new InformativeResponse();
+
+        successResponse.code = 200;
+        successResponse.message = "Access Control entry has been deleted successfully.";
+
+        return Response.ok().entity(successResponse).build();
     }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
@@ -50,6 +50,11 @@ public abstract class AbstractModulator<E extends Entity> extends AccessModulato
         get().modifyPermission(accessControl);
     }
 
+    @Override
+    public void deletePermission(AccessControl accessControl) {
+         get().deletePermission(accessControl);
+    }
+
     public abstract AccessAlwaysModulator always();
 
     public abstract AccessEntityModulator entity();

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
@@ -50,4 +50,9 @@ public abstract class AccessAlwaysModulator<E extends Entity> extends AccessModu
     public void modifyPermission(AccessControl accessControl) {
         getAccessControlRepository().update(accessControl);
     }
+
+    @Override
+    public void deletePermission(AccessControl accessControl) {
+         getAccessControlRepository().delete(accessControl);
+    }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessControlModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessControlModulator.java
@@ -88,7 +88,13 @@ public abstract class AccessControlModulator<E extends Entity> extends AccessMod
     @Override
     public void modifyPermission(AccessControl accessControl) {
 
-        throw new ForbiddenException("You have no access to modify these permissions.");
+        throw new ForbiddenException("You have no access to modify this permission.");
+    }
+
+    @Override
+    public void deletePermission(AccessControl accessControl) {
+
+        throw new ForbiddenException("You have no access to delete this permission.");
     }
 
     private Optional<AccessControl> getAccessControl(ObjectId id, AccessControlPermission permission){

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessEntityModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessEntityModulator.java
@@ -82,6 +82,16 @@ public abstract class AccessEntityModulator<E extends Entity> extends AccessCont
         }
     }
 
+    @Override
+    public void deletePermission(AccessControl accessControl) {
+
+        if (isIdentifiable(accessControl.getCreatorId())) {
+             getAccessControlRepository().delete(accessControl);
+        } else {
+             super.deletePermission(accessControl);
+        }
+    }
+
     /**
      * Checks if the given id can be identified by the subject of an access token.
      *

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
@@ -49,6 +49,12 @@ public abstract class AccessModulator<E extends Entity> implements PanacheMongoR
      */
     public abstract void modifyPermission(AccessControl accessControl);
 
+    /**
+     * This method is responsible fοr deleting an existing permissions which have already been granted to specific entity
+     * @param accessControl It essentially expresses the permissions that will be deleted
+     */
+    public abstract void deletePermission(AccessControl accessControl);
+
     public List<E> combineTwoLists(List<E> a, List<E> b){
 
         // We wanna avoid duplicates


### PR DESCRIPTION
You can delete an existing Access Control entry.

A mechanism has been created that allows the deletion of Access Control entry. Only the Metric Definition mechanism
has been activated in this commit.

ACC-50