### PR TITLE
[ACC-51] Read Access Control Entries

### DIFF
--- a/src/main/java/org/accounting/system/dtos/acl/AccessControlResponseDto.java
+++ b/src/main/java/org/accounting/system/dtos/acl/AccessControlResponseDto.java
@@ -53,5 +53,5 @@ public class AccessControlResponseDto {
             description = "This component is a set of permissions."
     )
     @JsonProperty("permissions")
-    public Set<AccessControlPermission> permissions;
+    public Set<String> permissions;
 }

--- a/src/main/java/org/accounting/system/mappers/AccessControlMapper.java
+++ b/src/main/java/org/accounting/system/mappers/AccessControlMapper.java
@@ -9,6 +9,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
+import java.util.List;
+
 /**
  * This interface is responsible for turning an Access Control Entity into a request/response and vice versa.
  */
@@ -21,6 +23,8 @@ public interface AccessControlMapper {
     AccessControl requestToAccessControl(AccessControlRequestDto request);
 
     AccessControlResponseDto accessControlToResponse(AccessControl response);
+
+    List<AccessControlResponseDto> accessControlsToResponse(List<AccessControl> accessControls);
 
     @Mapping(target = "who", ignore = true)
     @Mapping(target = "collection", ignore = true)

--- a/src/main/java/org/accounting/system/repositories/acl/AccessControlRepository.java
+++ b/src/main/java/org/accounting/system/repositories/acl/AccessControlRepository.java
@@ -6,6 +6,7 @@ import org.accounting.system.enums.Collection;
 import org.accounting.system.enums.acl.AccessControlPermission;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.NotFoundException;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,11 +23,11 @@ public class AccessControlRepository implements PanacheMongoRepository<AccessCon
     /**
      * Returns a specific Collection entity to which a service/user may has {permission} access.
      *
-     * @param who the one to whom the permission may be granted
+     * @param who The one to whom the permission may be granted
      * @param collection The name of the Collection
-     * @param entity entity id
-     * @param permission access control permission
-     * @return the Access Control that may grant access to a service/user in a particular entity
+     * @param entity The entity id
+     * @param permission Access control permission
+     * @return |The Access Control that may grant access to a service/user in a particular entity
      */
     public Optional<AccessControl> findByWhoAndCollectionAndEntityAndPermission(String who, Collection collection, String entity, AccessControlPermission permission){
 
@@ -35,12 +36,12 @@ public class AccessControlRepository implements PanacheMongoRepository<AccessCon
 
     /**
      * Returns all Collection entities to which a service/user has {permission} access
-     * @param who the one to whom the permissions have been granted
-     * @param collection the name of the Collection
-     * @param permission access control permission
-     * @return the available access controls that grant access to a service/user in a Collection
+     * @param who The one to whom the permissions have been granted
+     * @param collection The name of the Collection
+     * @param permission Access control permission
+     * @return The available access controls that grant access to a service/user in a Collection
      */
-    public List<AccessControl> findByWhoAndCollection(String who, Collection collection, AccessControlPermission permission){
+    public List<AccessControl> findAllByWhoAndCollection(String who, Collection collection, AccessControlPermission permission){
 
         return list("who = ?1 and collection = ?2 and permissions in ?3", who, collection, permission);
     }
@@ -50,11 +51,34 @@ public class AccessControlRepository implements PanacheMongoRepository<AccessCon
      *
      * @param who the one to whom the permission may be granted
      * @param collection The name of the Collection
-     * @param entity entity id
+     * @param entity The entity id
      * @return the Access Control that may grant access to a service/user in a particular entity
      */
-    public Optional<AccessControl> findByWhoAndCollectionAndEntity(String who, Collection collection, String entity){
+    public AccessControl findByWhoAndCollectionAndEntity(String who, Collection collection, String entity){
 
-        return find("who = ?1 and collection = ?2 and entity = ?3", who, collection, entity).stream().findAny();
+        var optional =  find("who = ?1 and collection = ?2 and entity = ?3", who, collection, entity).stream().findAny();
+
+        return optional.orElseThrow(()->new NotFoundException("There is no assigned permission for the "+who+" to control access to the "+entity));
+    }
+
+    /**
+     * Returns all Access Controls that have been created for given collection
+     * @param collection The name of the Collection
+     * @return The available access controls that grant access to a service/user in a Collection
+     */
+    public List<AccessControl> findAllByCollection(Collection collection){
+
+        return list("collection = ?1" , collection);
+    }
+
+    /**
+     * Returns all Access Controls that have been created for given collection and created by given creatorId
+     * @param collection The name of the Collection
+     * @param creatorId  The creator id
+     * @return The available access controls that grant access to a service/user in a Collection
+     */
+    public List<AccessControl> findAllByCollectionAndCreatorId(Collection collection, String creatorId){
+
+        return list("collection = ?1 and creatorId = ?2" , collection, creatorId);
     }
 }

--- a/src/main/java/org/accounting/system/repositories/authorization/RoleAccessControlRepository.java
+++ b/src/main/java/org/accounting/system/repositories/authorization/RoleAccessControlRepository.java
@@ -1,0 +1,10 @@
+package org.accounting.system.repositories.authorization;
+
+import org.accounting.system.entities.authorization.Role;
+import org.accounting.system.repositories.modulators.AccessControlModulator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RoleAccessControlRepository extends AccessControlModulator<Role> {
+}

--- a/src/main/java/org/accounting/system/repositories/authorization/RoleAccessEntityRepository.java
+++ b/src/main/java/org/accounting/system/repositories/authorization/RoleAccessEntityRepository.java
@@ -1,11 +1,20 @@
 package org.accounting.system.repositories.authorization;
 
 import org.accounting.system.entities.authorization.Role;
+import org.accounting.system.repositories.modulators.AccessControlModulator;
 import org.accounting.system.repositories.modulators.AccessEntityModulator;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 @ApplicationScoped
 public class RoleAccessEntityRepository extends AccessEntityModulator<Role> {
 
+    @Inject
+    RoleAccessControlRepository roleAccessControlRepository;
+
+    @Override
+    public AccessControlModulator<Role> accessControlModulator() {
+        return roleAccessControlRepository;
+    }
 }

--- a/src/main/java/org/accounting/system/repositories/authorization/RoleModulator.java
+++ b/src/main/java/org/accounting/system/repositories/authorization/RoleModulator.java
@@ -1,7 +1,10 @@
 package org.accounting.system.repositories.authorization;
 
+import org.accounting.system.dtos.authorization.update.UpdateRoleRequestDto;
 import org.accounting.system.entities.authorization.Role;
+import org.accounting.system.mappers.RoleMapper;
 import org.accounting.system.repositories.modulators.AbstractModulator;
+import org.bson.types.ObjectId;
 
 import javax.inject.Inject;
 
@@ -13,6 +16,14 @@ public class RoleModulator extends AbstractModulator<Role> {
     @Inject
     RoleAccessEntityRepository roleAccessEntityRepository;
 
+    public Role updateEntity(ObjectId id, UpdateRoleRequestDto updateRoleRequestDto) {
+
+        Role entity = findById(id);
+
+        RoleMapper.INSTANCE.updateRoleFromDto(updateRoleRequestDto, entity);
+
+        return super.updateEntity(entity);
+    }
 
     @Override
     public RoleAccessAlwaysRepository always() {

--- a/src/main/java/org/accounting/system/repositories/authorization/RoleRepository.java
+++ b/src/main/java/org/accounting/system/repositories/authorization/RoleRepository.java
@@ -1,12 +1,8 @@
 package org.accounting.system.repositories.authorization;
 
-import org.accounting.system.dtos.authorization.update.UpdateRoleRequestDto;
 import org.accounting.system.entities.authorization.Permission;
 import org.accounting.system.entities.authorization.Role;
 import org.accounting.system.enums.Collection;
-import org.accounting.system.mappers.RoleMapper;
-import org.accounting.system.repositories.modulators.AbstractModulator;
-import org.bson.types.ObjectId;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -19,11 +15,13 @@ import java.util.stream.Collectors;
  * that can be performed on the {@link Role} collection. It is also responsible for mapping
  * the data from the storage format to the {@link Role}.
  *
- * Since {@link RoleRepository} extends {@link AbstractModulator},
- * it has to provide it with the corresponding {@link org.accounting.system.repositories.modulators.AccessModulator} implementations.
- * Also, all the operations that are defined on {@link io.quarkus.mongodb.panache.PanacheMongoRepository} and on
- * {@link org.accounting.system.repositories.modulators.AccessModulator} are available on this repository.
+ * Since {@link RoleRepository this repository} extends {@link RoleModulator},
+ * it has access to all queries, which determine the degree of accessibility of the data.
+ *
+ * Also, all the operations that are defined on {@link io.quarkus.mongodb.panache.PanacheMongoRepository} are available on this repository.
+ * In this repository, we essentially define the queries that will be executed on the database without any restrictions.
  */
+
 @ApplicationScoped
 public class RoleRepository extends RoleModulator {
 
@@ -51,14 +49,5 @@ public class RoleRepository extends RoleModulator {
      */
     public Optional<Role> getRoleByName(String name){
         return find("name = ?1", name).stream().findFirst();
-    }
-
-    public Role updateEntity(ObjectId id, UpdateRoleRequestDto updateRoleRequestDto) {
-
-        Role entity = findById(id);
-
-        RoleMapper.INSTANCE.updateRoleFromDto(updateRoleRequestDto, entity);
-
-        return super.updateEntity(entity);
     }
 }

--- a/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionAccessControlRepository.java
+++ b/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionAccessControlRepository.java
@@ -1,0 +1,11 @@
+package org.accounting.system.repositories.metricdefinition;
+
+import org.accounting.system.entities.MetricDefinition;
+import org.accounting.system.repositories.modulators.AccessControlModulator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MetricDefinitionAccessControlRepository extends AccessControlModulator<MetricDefinition> {
+
+}

--- a/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionAccessEntityRepository.java
+++ b/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionAccessEntityRepository.java
@@ -1,11 +1,20 @@
 package org.accounting.system.repositories.metricdefinition;
 
 import org.accounting.system.entities.MetricDefinition;
+import org.accounting.system.repositories.modulators.AccessControlModulator;
 import org.accounting.system.repositories.modulators.AccessEntityModulator;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 @ApplicationScoped
 public class MetricDefinitionAccessEntityRepository extends AccessEntityModulator<MetricDefinition> {
 
+    @Inject
+    MetricDefinitionAccessControlRepository metricDefinitionAccessControlRepository;
+
+    @Override
+    public AccessControlModulator<MetricDefinition> accessControlModulator() {
+        return metricDefinitionAccessControlRepository;
+    }
 }

--- a/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionModulator.java
+++ b/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionModulator.java
@@ -1,7 +1,10 @@
 package org.accounting.system.repositories.metricdefinition;
 
+import org.accounting.system.dtos.UpdateMetricDefinitionRequestDto;
 import org.accounting.system.entities.MetricDefinition;
+import org.accounting.system.mappers.MetricDefinitionMapper;
 import org.accounting.system.repositories.modulators.AbstractModulator;
+import org.bson.types.ObjectId;
 
 import javax.inject.Inject;
 
@@ -15,6 +18,14 @@ public class MetricDefinitionModulator extends AbstractModulator<MetricDefinitio
     @Inject
     MetricDefinitionAccessAlwaysRepository metricDefinitionAccessAlwaysRepository;
 
+    public MetricDefinition updateEntity(ObjectId id, UpdateMetricDefinitionRequestDto updateMetricDefinitionRequestDto) {
+
+        MetricDefinition entity = findById(id);
+
+        MetricDefinitionMapper.INSTANCE.updateMetricDefinitionFromDto(updateMetricDefinitionRequestDto, entity);
+
+        return super.updateEntity(entity);
+    }
 
     @Override
     public MetricDefinitionAccessAlwaysRepository always() {

--- a/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionRepository.java
+++ b/src/main/java/org/accounting/system/repositories/metricdefinition/MetricDefinitionRepository.java
@@ -1,24 +1,21 @@
 package org.accounting.system.repositories.metricdefinition;
 
-import org.accounting.system.dtos.UpdateMetricDefinitionRequestDto;
 import org.accounting.system.entities.MetricDefinition;
-import org.accounting.system.mappers.MetricDefinitionMapper;
-import org.accounting.system.repositories.modulators.AbstractModulator;
-import org.bson.types.ObjectId;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.Optional;
 
 /**
- * This repository {@link MetricDefinitionRepository} encapsulates the logic required to access
+ * {@link MetricDefinitionRepository This repository} encapsulates the logic required to access
  * {@link MetricDefinition} data stored in the mongo database. More specifically, it encapsulates the queries
  * that can be performed on the {@link MetricDefinition} collection. It is also responsible for mapping
  * the data from the storage format to the {@link MetricDefinition}.
  *
- * Since {@link MetricDefinitionRepository} extends {@link AbstractModulator},
- * it has to provide it with the corresponding {@link org.accounting.system.repositories.modulators.AccessModulator} implementations.
- * Also, all the operations that are defined on {@link io.quarkus.mongodb.panache.PanacheMongoRepository} and on
- * {@link org.accounting.system.repositories.modulators.AccessModulator} are available on this repository.
+ * Since {@link MetricDefinitionRepository this repository} extends {@link MetricDefinitionModulator},
+ * it has access to all queries, which determine the degree of accessibility of the data.
+ *
+ * Also, all the operations that are defined on {@link io.quarkus.mongodb.panache.PanacheMongoRepository} are available on this repository.
+ * In this repository, we essentially define the queries that will be executed on the database without any restrictions.
  */
 @ApplicationScoped
 public class MetricDefinitionRepository extends MetricDefinitionModulator {
@@ -26,14 +23,5 @@ public class MetricDefinitionRepository extends MetricDefinitionModulator {
     public Optional<MetricDefinition> exist(String unitType, String name){
 
         return find("unitType = ?1 and metricName = ?2", unitType, name.toLowerCase()).stream().findAny();
-    }
-
-    public MetricDefinition updateEntity(ObjectId id, UpdateMetricDefinitionRequestDto updateMetricDefinitionRequestDto) {
-
-        MetricDefinition entity = findById(id);
-
-        MetricDefinitionMapper.INSTANCE.updateMetricDefinitionFromDto(updateMetricDefinitionRequestDto, entity);
-
-        return super.updateEntity(entity);
     }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AbstractModulator.java
@@ -55,6 +55,16 @@ public abstract class AbstractModulator<E extends Entity> extends AccessModulato
          get().deletePermission(accessControl);
     }
 
+    @Override
+    public AccessControl getPermission(String entity, String who) {
+        return get().getPermission(entity, who);
+    }
+
+    @Override
+    public List<AccessControl> getAllPermissions() {
+        return get().getAllPermissions();
+    }
+
     public abstract AccessAlwaysModulator always();
 
     public abstract AccessEntityModulator entity();

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessAlwaysModulator.java
@@ -17,13 +17,11 @@ public abstract class AccessAlwaysModulator<E extends Entity> extends AccessModu
 
     @Override
     public E fetchEntityById(ObjectId id) {
-
         return findById(id);
     }
 
     @Override
     public boolean deleteEntityById(ObjectId id) {
-
         return deleteById(id);
     }
 
@@ -36,13 +34,11 @@ public abstract class AccessAlwaysModulator<E extends Entity> extends AccessModu
 
     @Override
     public List<E> getAllEntities() {
-
         return findAll().list();
     }
 
     @Override
     public void grantPermission(AccessControl accessControl) {
-
          getAccessControlRepository().persist(accessControl);
     }
 
@@ -54,5 +50,15 @@ public abstract class AccessAlwaysModulator<E extends Entity> extends AccessModu
     @Override
     public void deletePermission(AccessControl accessControl) {
          getAccessControlRepository().delete(accessControl);
+    }
+
+    @Override
+    public AccessControl getPermission(String entity, String who) {
+        return getAccessControlRepository().findByWhoAndCollectionAndEntity(who, collection(), entity);
+    }
+
+    @Override
+    public List<AccessControl> getAllPermissions() {
+        return getAccessControlRepository().findAllByCollection(collection());
     }
 }

--- a/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
+++ b/src/main/java/org/accounting/system/repositories/modulators/AccessModulator.java
@@ -1,14 +1,18 @@
 package org.accounting.system.repositories.modulators;
 
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import net.jodah.typetools.TypeResolver;
 import org.accounting.system.beans.RequestInformation;
 import org.accounting.system.entities.Entity;
 import org.accounting.system.entities.acl.AccessControl;
+import org.accounting.system.enums.Collection;
 import org.accounting.system.repositories.acl.AccessControlRepository;
 import org.bson.types.ObjectId;
 
 import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,31 +33,68 @@ public abstract class AccessModulator<E extends Entity> implements PanacheMongoR
     @Inject
     AccessControlRepository accessControlRepository;
 
-    public abstract E fetchEntityById(ObjectId id);
+    protected Class<E> clazz;
 
-    public abstract boolean deleteEntityById(ObjectId id);
+    public AccessModulator(){
+        Class<?> type = TypeResolver.resolveRawArgument(AccessModulator.class, getClass());
+        clazz = (Class<E>) type;
+    }
 
-    public abstract E updateEntity(E entity);
+    public  E fetchEntityById(ObjectId id){
+        throw new ForbiddenException("You have no access to this entity : " + id.toString());
+    }
 
-    public abstract List<E> getAllEntities();
+    public boolean deleteEntityById(ObjectId id){
+        throw new ForbiddenException("You have no access to this entity : " + id.toString());
+    }
+
+    public E updateEntity(E entity){
+        throw new ForbiddenException("You have no access to this entity : " + entity.getId().toString());
+    }
+
+    public List<E> getAllEntities(){
+        return Collections.emptyList();
+    }
 
     /**
-     * This method is responsible fοr granting permissions to specific entity within a generic collection
-     * @param accessControl It essentially expresses the permissions that will be granted
+     * This method is responsible fοr granting permissions to specific entity within a generic collection.
+     * @param accessControl It essentially expresses the permissions that will be granted.
      */
-    public abstract void grantPermission(AccessControl accessControl);
+    public void grantPermission(AccessControl accessControl){
+        throw new ForbiddenException("You have no access to this entity : " + accessControl.getEntity());
+    }
 
     /**
-     * This method is responsible fοr updating an existing permissions which have already been granted to specific entity
-     * @param accessControl It essentially expresses the permissions that will be modified
+     * This method is responsible fοr updating existing permissions which have already been granted to a specific entity.
+     * @param accessControl It essentially expresses the permissions that will be modified.
      */
-    public abstract void modifyPermission(AccessControl accessControl);
+    public void modifyPermission(AccessControl accessControl){
+        throw new ForbiddenException("You have no access to modify this permission.");
+    }
 
     /**
-     * This method is responsible fοr deleting an existing permissions which have already been granted to specific entity
-     * @param accessControl It essentially expresses the permissions that will be deleted
+     * This method is responsible fοr deleting existing permissions which have already been granted to a specific entity.
+     * @param accessControl It essentially expresses the permissions that will be deleted.
      */
-    public abstract void deletePermission(AccessControl accessControl);
+    public void deletePermission(AccessControl accessControl){
+        throw new ForbiddenException("You have no access to delete this permission.");
+    }
+
+    /**
+     * This method is responsible fοr fetching existing permissions which have already been granted to a specific entity.
+     * @param entity The entity id to which permissions have been assigned.
+     * @param who To whom the permissions have been assigned.
+     */
+    public AccessControl getPermission(String entity, String who){
+        throw new ForbiddenException("You have no access to read this permission.");
+    }
+
+    /**
+     * This method is responsible for returning all permissions granted in a Collection.
+     */
+    public List<AccessControl> getAllPermissions(){
+        return Collections.emptyList();
+    }
 
     public List<E> combineTwoLists(List<E> a, List<E> b){
 
@@ -72,5 +113,9 @@ public abstract class AccessModulator<E extends Entity> implements PanacheMongoR
 
     public AccessControlRepository getAccessControlRepository() {
         return accessControlRepository;
+    }
+
+    public Collection collection(){
+        return Collection.valueOf(clazz.getSimpleName());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,7 +75,8 @@ keycloak.server.client.id=accounting-system-public
 %test.quarkus.keycloak.devservices.users.test=test
 %test.quarkus.keycloak.devservices.roles.test=test_role
 
-
+%test.quarkus.keycloak.devservices.users.madmin=madmin
+%test.quarkus.keycloak.devservices.roles.madmin=metric_definition_admin
 
 %dev.quarkus.keycloak.devservices.users.admin=admin
 %dev.quarkus.keycloak.devservices.roles.admin=system_admin


### PR DESCRIPTION
You can read one or all of the Access Control entities based on the permissions that have been assigned to you.

A mechanism has been created that allows the reading of Access Control entries. Only the Metric Definition mechanism
has been activated in this commit.

ACC-51