### PR TITLE
remove object id from metricDefinitionResponseDTO

### DIFF
--- a/src/main/java/org/accounting/system/dtos/metricdefinition/MetricDefinitionResponseDto.java
+++ b/src/main/java/org/accounting/system/dtos/metricdefinition/MetricDefinitionResponseDto.java
@@ -56,9 +56,7 @@ public class MetricDefinitionResponseDto {
     @JsonProperty("metric_type")
     public String metricType;
 
-    public ObjectId getObjectId(){
-        return new ObjectId(this.id);
-
+    public String getId() {
+        return id;
     }
-
 }

--- a/src/main/java/org/accounting/system/services/MetricDefinitionService.java
+++ b/src/main/java/org/accounting/system/services/MetricDefinitionService.java
@@ -265,9 +265,9 @@ public class MetricDefinitionService {
     }
     public List<MetricDefinitionResponseDto> searchMetricDefinition( String json, boolean isAlwaysPermission) throws ParseException, NoSuchFieldException {
 
-        List<ObjectId> entityIds=new ArrayList<>();
+        List<String> entityIds=new ArrayList<>();
         if(!isAlwaysPermission){
-            entityIds= fetchAllMetricDefinitions().stream().map(MetricDefinitionResponseDto::getObjectId).collect(Collectors.toList());
+            entityIds= fetchAllMetricDefinitions().stream().map(MetricDefinitionResponseDto::getId).collect(Collectors.toList());
         }
         Bson query=queryParser.parseFile(json, isAlwaysPermission, entityIds);
         return  MetricDefinitionMapper.INSTANCE.metricDefinitionsToResponse( metricDefinitionRepository.search(query));

--- a/src/main/java/org/accounting/system/util/QueryParser.java
+++ b/src/main/java/org/accounting/system/util/QueryParser.java
@@ -22,7 +22,7 @@ import java.util.List;
 @ApplicationScoped
 public class QueryParser {
 
-    public Bson parseFile(String json, boolean isAlwaysPermission, List<ObjectId> objectIds) throws ParseException, NoSuchFieldException {
+    public Bson parseFile(String json, boolean isAlwaysPermission, List<String> objectIds) throws ParseException, NoSuchFieldException {
         if (json != null) {
             JSONParser parser = new JSONParser();
             JSONObject jsonObject = (JSONObject) parser.parse(json);
@@ -167,9 +167,14 @@ public class QueryParser {
 
     }
 
-    public Bson accessFilter(Bson filter, List<ObjectId> ids) {
+    public Bson accessFilter(Bson filter, List<String> ids) {
 
-        Bson accessFilter = Filters.in("_id", ids);
+        List<ObjectId> objectIds=new ArrayList<>();
+        for(String stId: ids){
+
+            objectIds.add(new ObjectId(stId));
+        }
+        Bson accessFilter = Filters.in("_id", objectIds);
 
         Bson query = Filters.and(accessFilter, filter);
         return query;


### PR DESCRIPTION
Removed objectId from MetricDefinitionResponseDTO in order to remove it from appearing as a response field