### PR TITLE
[ACC-81] Forbidding to delete Providers that belongs to a Project

### DIFF
--- a/src/main/java/org/accounting/system/repositories/HierarchicalRelationRepository.java
+++ b/src/main/java/org/accounting/system/repositories/HierarchicalRelationRepository.java
@@ -60,9 +60,9 @@ public class HierarchicalRelationRepository implements PanacheMongoRepositoryBas
      * @param path Hierarchical relationship path
      * @return if the given path exists.
      */
-    public boolean hierarchicalRelationshipExists(String path){
+    public boolean exist(String path){
 
-        Bson regex = Aggregates.match(Filters.regex("_id", path));
+        Bson regex = Aggregates.match(Filters.regex("_id","\\b" + path + "\\b"+"(?![-])"));
 
         Document count = getMongoCollection()
                 .aggregate(List
@@ -70,6 +70,7 @@ public class HierarchicalRelationRepository implements PanacheMongoRepositoryBas
 
         return count != null && Long.parseLong(count.get("count").toString()) > 0L;
     }
+
 
     public HierarchicalRelation findByPath(final String id){
 
@@ -165,7 +166,7 @@ public class HierarchicalRelationRepository implements PanacheMongoRepositoryBas
 
     public ProjectionQuery<MetricProjection> findByExternalId(final String externalId, int page, int size) {
         //Bson regex = Aggregates.match(Filters.regex("resource_id", externalId + "[.\\s]"));
-        Bson regex = Aggregates.match(Filters.regex("resource_id", externalId));
+        Bson regex = Aggregates.match(Filters.regex("resource_id", "\\b" + externalId + "\\b"+"(?![-])"));
 
         List<MetricProjection> projections = metricRepository
                 .getMongoCollection()

--- a/src/main/java/org/accounting/system/services/HierarchicalRelationService.java
+++ b/src/main/java/org/accounting/system/services/HierarchicalRelationService.java
@@ -86,8 +86,21 @@ public class HierarchicalRelationService {
      */
     public boolean providerBelongsToProject(String projectId, String providerId){
 
-        return hierarchicalRelationRepository.hierarchicalRelationshipExists(projectId + HierarchicalRelation.PATH_SEPARATOR + providerId);
+        return hierarchicalRelationRepository.exist(projectId + HierarchicalRelation.PATH_SEPARATOR + providerId);
     }
+
+
+    /**
+     * This method delegates to {@link HierarchicalRelationRepository hierarchicalRelationRepository} to check if the given Provider belongs to any Project
+     **
+     * @param providerId The Provider ID.
+     * @return if provider belongs to any project.
+     */
+    public boolean providerBelongsToAnyProject(String providerId){
+
+        return hierarchicalRelationRepository.exist(providerId);
+    }
+
 
     public void recursion(HierarchicalRelationProjection relation, Set<Document> metrics){
 

--- a/src/main/java/org/accounting/system/services/ProviderService.java
+++ b/src/main/java/org/accounting/system/services/ProviderService.java
@@ -34,6 +34,9 @@ public class ProviderService {
     @Inject
     HierarchicalRelationRepository hierarchicalRelationRepository;
 
+    @Inject
+    HierarchicalRelationService hierarchicalRelationService;
+
 
     /**
      * Returns the N Providers from the given page.
@@ -103,6 +106,10 @@ public class ProviderService {
         // if Provider's creator id is null then it derives from EOSC-Portal
         if(Objects.isNull(provider.getCreatorId())){
             throw new ForbiddenException("You cannot delete a Provider which derives from EOSC-Portal.");
+        }
+
+        if(hierarchicalRelationService.providerBelongsToAnyProject(providerId)){
+            throw new ForbiddenException("You cannot delete a Provider which belongs to a Project.");
         }
 
         return providerRepository.deleteEntityById(providerId);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,14 +62,6 @@ quarkus.oidc.credentials.secret=secret
 %test.quarkus.oidc.credentials.secret=secret
 %test.quarkus.oidc.application-type=service
 
-%dev.quarkus.oidc.authorization-path=/protocol/openid-connect/auth
-%dev.quarkus.oidc.token-path=/protocol/openid-connect/token
-%dev.quarkus.oidc.discovery-enabled=false
-%dev.quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect
-%dev.quarkus.oidc.client-id=accounting-system
-%dev.quarkus.oidc.credentials.secret=secret
-%dev.quarkus.oidc.application-type=service
-
 # keycloak properties for feeding the keycloak html template
 keycloak.server.url=https://login-devel.einfra.grnet.gr/auth
 keycloak.server.realm=einfra
@@ -106,34 +98,6 @@ keycloak.server.client.id=accounting-system-public
 
 %test.quarkus.keycloak.devservices.users.installationcreator=installationcreator
 %test.quarkus.keycloak.devservices.roles.installationcreator=installation_creator
-
-
-%dev.quarkus.keycloak.devservices.users.admin=admin
-%dev.quarkus.keycloak.devservices.roles.admin=metric_definition_admin, role_admin, client_admin, provider_admin
-
-%dev.quarkus.keycloak.devservices.users.madmin=madmin
-%dev.quarkus.keycloak.devservices.roles.madmin=metric_definition_admin
-
-%dev.quarkus.keycloak.devservices.users.projectadmin=projectadmin
-%dev.quarkus.keycloak.devservices.roles.projectadmin=metric_definition_creator, provider_creator, client_reader
-
-%dev.quarkus.keycloak.devservices.users.provideradmin=provideradmin
-%dev.quarkus.keycloak.devservices.roles.provideradmin=provider_creator, metric_definition_creator, client_reader
-
-%dev.quarkus.keycloak.devservices.users.installationadmin=installationadmin
-%dev.quarkus.keycloak.devservices.roles.installationadmin=metric_definition_creator, client_reader
-
-%dev.quarkus.keycloak.devservices.users.inspector=inspector
-%dev.quarkus.keycloak.devservices.roles.inspector=metric_definition_inspector
-
-%dev.quarkus.keycloak.devservices.users.combine=combine
-%dev.quarkus.keycloak.devservices.roles.combine=metric_definition_admin
-
-%dev.quarkus.keycloak.devservices.users.creator=creator
-%dev.quarkus.keycloak.devservices.roles.creator=metric_definition_creator
-
-%dev.quarkus.keycloak.devservices.users.installationcreator=installationcreator
-%dev.quarkus.keycloak.devservices.roles.installationcreator=installation_creator
 
 disable.authorization=false
 


### PR DESCRIPTION
You cannot delete a Provider created through Accounting System API and belongs to a particular Project.

ACC-81