### PR TITLE
Generate a new Role named project_reader

### DIFF
--- a/src/main/java/org/accounting/system/endpoints/ProjectEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/ProjectEndpoint.java
@@ -1402,8 +1402,8 @@ public class ProjectEndpoint {
     @Tag(name = "Project")
     @Operation(
             operationId = "get-all-projects",
-            summary = "Get all projects",
-            description = "Get all Projects" )
+            summary = "Returns all Projects to which a client has access.",
+            description = "Returns all Projects to which a client has access." )
 
     @APIResponse(
             responseCode = "200",

--- a/src/main/java/org/accounting/system/templates/RoleTemplate.java
+++ b/src/main/java/org/accounting/system/templates/RoleTemplate.java
@@ -28,7 +28,7 @@ public class RoleTemplate {
     @Operation(hidden = true)
     public String keycloakClient() {
         return role
-                .data("roles", roleRepository.findAll().list())
+                .data("roles", roleRepository.find("system = ?1", false).list())
                 .render();
     }
 }

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -572,4 +572,44 @@
             </ext:documents>
         </ext:insertMany>
     </changeSet>
+
+    <changeSet id="15" author="accounting-system">
+        <ext:insertOne collectionName="Role">
+            <ext:document>
+                {
+                system: false,
+                name: "project_reader",
+                description: "project_reader can read all entities related to the Project it will be applied to.",
+                collections_access_permissions: [
+                {
+                access_permissions: [
+                {
+                operation: "READ",
+                access_type: "ALWAYS"
+                }
+                ],
+                collection: "Project"
+                },
+                {
+                access_permissions: [
+                {
+                operation: "READ",
+                access_type: "ALWAYS"
+                }
+                ],
+                collection: "Metric"
+                },
+                {
+                access_permissions: [
+                {
+                operation: "READ",
+                access_type: "ALWAYS"
+                }
+                ],
+                collection: "Installation"
+                }]
+                }
+            </ext:document>
+        </ext:insertOne>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The project_reader role has been created. It can read all entities related to the Project it will be applied to.