### PR TITLE
Deleting an Installation is not allowed if there are Metrics assigned to it

### DIFF
--- a/src/main/java/org/accounting/system/entities/Metric.java
+++ b/src/main/java/org/accounting/system/entities/Metric.java
@@ -43,7 +43,7 @@ public class Metric extends Entity {
     @BsonProperty("project_id")
     private String projectId;
     @BsonProperty("installation_id")
-   private String installationId;
+    private String installationId;
 
     public String getResourceId() {
         return resourceId;

--- a/src/main/java/org/accounting/system/repositories/metric/MetricRepository.java
+++ b/src/main/java/org/accounting/system/repositories/metric/MetricRepository.java
@@ -144,4 +144,8 @@ public class MetricRepository extends MetricModulator {
 
         return projectionQuery;
     }
+
+    public Optional<Metric> findFirstByInstallationId(String installationId){
+        return find("installation_id", installationId).firstResultOptional();
+    }
 }

--- a/src/main/java/org/accounting/system/services/installation/InstallationService.java
+++ b/src/main/java/org/accounting/system/services/installation/InstallationService.java
@@ -21,6 +21,7 @@ import org.accounting.system.mappers.MetricMapper;
 import org.accounting.system.repositories.HierarchicalRelationRepository;
 import org.accounting.system.repositories.authorization.RoleRepository;
 import org.accounting.system.repositories.installation.InstallationRepository;
+import org.accounting.system.repositories.metric.MetricRepository;
 import org.accounting.system.repositories.provider.ProviderRepository;
 import org.accounting.system.services.HierarchicalRelationService;
 import org.accounting.system.services.acl.RoleAccessControlService;
@@ -30,6 +31,7 @@ import org.bson.conversions.Bson;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriInfo;
 import java.util.ArrayList;
@@ -52,6 +54,9 @@ public class InstallationService implements RoleAccessControlService {
 
     @Inject
     RoleRepository roleRepository;
+
+    @Inject
+    MetricRepository metricRepository;
 
     @Inject
     HierarchicalRelationRepository hierarchicalRelationRepository;
@@ -84,6 +89,13 @@ public class InstallationService implements RoleAccessControlService {
      * @return If the operation is successful or not.
      */
     public void delete(String installationId) {
+
+        if(!metricRepository
+                .findFirstByInstallationId(installationId)
+                .isEmpty()){
+
+            throw new ForbiddenException("Deleting an Installation is not allowed if there are Metrics assigned to it.");
+        }
 
         var installation = fetchInstallationProjection(installationId);
 


### PR DESCRIPTION
Currently, we don't check if there are Metrics under an Installation, so one client can delete that Installation. We must forbid that.