### PR TITLE
MetricDefinition filtering on Metrics

### DIFF
--- a/src/main/java/org/accounting/system/filters/LoggingFilter.java
+++ b/src/main/java/org/accounting/system/filters/LoggingFilter.java
@@ -1,0 +1,44 @@
+package org.accounting.system.filters;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class LoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final Logger LOG = Logger.getLogger(LoggingFilter.class);
+    @Context
+    UriInfo info;
+
+    @Context
+    HttpServerRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext context) throws IOException {
+
+        final String method = context.getMethod();
+        final String path = info.getPath();
+        final String address = request.remoteAddress().toString();
+
+        LOG.infof("Request %s %s from IP %s.", method, path, address);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
+
+        final String method = containerRequestContext.getMethod();
+        final String path = info.getPath();
+        final String address = request.remoteAddress().toString();
+
+        LOG.infof("Request %s %s from IP %s has been completed. Response status is %s.", method, path, address, containerResponseContext.getStatus());
+    }
+}

--- a/src/main/java/org/accounting/system/services/MetricService.java
+++ b/src/main/java/org/accounting/system/services/MetricService.java
@@ -1,7 +1,6 @@
 package org.accounting.system.services;
 
 import com.mongodb.MongoWriteException;
-import io.quarkus.mongodb.panache.PanacheQuery;
 import io.quarkus.oidc.TokenIntrospection;
 import org.accounting.system.dtos.metric.MetricResponseDto;
 import org.accounting.system.dtos.metric.UpdateMetricRequestDto;
@@ -17,8 +16,6 @@ import org.accounting.system.repositories.metric.MetricRepository;
 import org.accounting.system.services.authorization.RoleService;
 import org.accounting.system.services.installation.InstallationService;
 import org.accounting.system.util.QueryParser;
-import org.accounting.system.util.Utility;
-import org.apache.commons.lang3.ObjectUtils;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -186,15 +183,9 @@ public class MetricService {
         return new PageResource<>(metrics, metrics.list(), uriInfo);
     }
 
-    public PageResource<MetricProjection> fetchAllMetrics(String id, int page, int size, UriInfo uriInfo, String start, String end){
+    public PageResource<MetricProjection> fetchAllMetrics(String id, int page, int size, UriInfo uriInfo, String start, String end, String metricDefinitionId){
 
-        PanacheQuery<MetricProjection> projection;
-
-        if(ObjectUtils.allNotNull(start, end) && Utility.isDate(start, end) && Utility.isBefore(start, end)) {
-            projection = metricRepository.findByExternalId(id, page, size, start, end);
-        } else{
-            projection = metricRepository.findByExternalId(id, page, size);
-        }
+        var projection = metricRepository.findByExternalId(id, page, size, start, end, metricDefinitionId);
 
         return new PageResource<>(projection, projection.list(), uriInfo);
     }

--- a/src/main/java/org/accounting/system/services/ProjectService.java
+++ b/src/main/java/org/accounting/system/services/ProjectService.java
@@ -6,6 +6,7 @@ import org.accounting.system.dtos.acl.role.RoleAccessControlRequestDto;
 import org.accounting.system.dtos.acl.role.RoleAccessControlResponseDto;
 import org.accounting.system.dtos.acl.role.RoleAccessControlUpdateDto;
 import org.accounting.system.dtos.installation.InstallationResponseDto;
+import org.accounting.system.dtos.metricdefinition.MetricDefinitionResponseDto;
 import org.accounting.system.dtos.pagination.PageResource;
 import org.accounting.system.entities.Project;
 import org.accounting.system.entities.authorization.Role;
@@ -15,6 +16,7 @@ import org.accounting.system.entities.projections.permissions.ProjectProjectionW
 import org.accounting.system.exceptions.ConflictException;
 import org.accounting.system.mappers.AccessControlMapper;
 import org.accounting.system.mappers.InstallationMapper;
+import org.accounting.system.mappers.MetricDefinitionMapper;
 import org.accounting.system.repositories.authorization.RoleRepository;
 import org.accounting.system.repositories.client.ClientAccessAlwaysRepository;
 import org.accounting.system.repositories.project.ProjectRepository;
@@ -97,6 +99,13 @@ public class ProjectService implements RoleAccessControlService {
         var projectionQuery = projectRepository.fetchClientPermissions(page, size);
 
         return new PageResource<>(projectionQuery, projectionQuery.list(), uriInfo);
+    }
+
+    public PageResource<MetricDefinitionResponseDto> fetchAllMetricDefinitions(String id, int page, int size, UriInfo uriInfo){
+
+        var projection = projectRepository.fetchAllMetricDefinitions(id, page, size);
+
+        return new PageResource<>(projection, MetricDefinitionMapper.INSTANCE.metricDefinitionsToResponse(projection.list()), uriInfo);
     }
 
     @Override

--- a/src/main/java/org/accounting/system/services/ProviderService.java
+++ b/src/main/java/org/accounting/system/services/ProviderService.java
@@ -5,6 +5,7 @@ import org.accounting.system.dtos.acl.role.RoleAccessControlRequestDto;
 import org.accounting.system.dtos.acl.role.RoleAccessControlResponseDto;
 import org.accounting.system.dtos.acl.role.RoleAccessControlUpdateDto;
 import org.accounting.system.dtos.installation.InstallationResponseDto;
+import org.accounting.system.dtos.metricdefinition.MetricDefinitionResponseDto;
 import org.accounting.system.dtos.pagination.PageResource;
 import org.accounting.system.dtos.provider.ProviderRequestDto;
 import org.accounting.system.dtos.provider.ProviderResponseDto;
@@ -16,6 +17,7 @@ import org.accounting.system.entities.provider.Provider;
 import org.accounting.system.exceptions.ConflictException;
 import org.accounting.system.mappers.AccessControlMapper;
 import org.accounting.system.mappers.InstallationMapper;
+import org.accounting.system.mappers.MetricDefinitionMapper;
 import org.accounting.system.mappers.ProviderMapper;
 import org.accounting.system.repositories.authorization.RoleRepository;
 import org.accounting.system.repositories.provider.ProviderRepository;
@@ -297,5 +299,12 @@ public class ProviderService implements RoleAccessControlService {
                 .collect(Collectors.toList());
 
         return new PageResource<>(panacheQuery, responses, uriInfo);
+    }
+
+    public PageResource<MetricDefinitionResponseDto> fetchAllMetricDefinitions(String projectId, String providerId, int page, int size, UriInfo uriInfo){
+
+        var projection = providerRepository.fetchAllMetricDefinitions(projectId, providerId, page, size);
+
+        return new PageResource<>(projection, MetricDefinitionMapper.INSTANCE.metricDefinitionsToResponse(projection.list()), uriInfo);
     }
 }

--- a/src/main/java/org/accounting/system/services/installation/InstallationService.java
+++ b/src/main/java/org/accounting/system/services/installation/InstallationService.java
@@ -8,6 +8,7 @@ import org.accounting.system.dtos.installation.InstallationResponseDto;
 import org.accounting.system.dtos.installation.UpdateInstallationRequestDto;
 import org.accounting.system.dtos.metric.MetricRequestDto;
 import org.accounting.system.dtos.metric.MetricResponseDto;
+import org.accounting.system.dtos.metricdefinition.MetricDefinitionResponseDto;
 import org.accounting.system.dtos.pagination.PageResource;
 import org.accounting.system.endpoints.InstallationEndpoint;
 import org.accounting.system.entities.HierarchicalRelation;
@@ -17,6 +18,7 @@ import org.accounting.system.entities.projections.InstallationProjection;
 import org.accounting.system.exceptions.ConflictException;
 import org.accounting.system.mappers.AccessControlMapper;
 import org.accounting.system.mappers.InstallationMapper;
+import org.accounting.system.mappers.MetricDefinitionMapper;
 import org.accounting.system.mappers.MetricMapper;
 import org.accounting.system.repositories.HierarchicalRelationRepository;
 import org.accounting.system.repositories.authorization.RoleRepository;
@@ -350,6 +352,13 @@ public class InstallationService implements RoleAccessControlService {
 
         return new PageResource<>(projection, InstallationMapper.INSTANCE.installationProjectionsToResponse(projection.list()), uriInfo);
 
+    }
+
+    public PageResource<MetricDefinitionResponseDto> fetchAllMetricDefinitions(String id, int page, int size, UriInfo uriInfo){
+
+        var projection = installationRepository.fetchAllMetricDefinitions(id, page, size);
+
+        return new PageResource<>(projection, MetricDefinitionMapper.INSTANCE.metricDefinitionsToResponse(projection.list()), uriInfo);
     }
 
 }


### PR DESCRIPTION
One client should be able to retrieve Project/Provider/Installation Metrics based on the MetricDefinition the Metrics are related to.