### PR TITLE
Caching data for containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             agent {
                 docker {
                     image 'argo.registry:5000/epel-7-java11-mvn384'
-                    args '-v /var/run/docker.sock:/var/run/docker.sock -u root:root'
+                    args '-v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -u root:root'
                 }
             }
             steps {

--- a/src/main/java/org/accounting/system/endpoints/InstallationEndpoint.java
+++ b/src/main/java/org/accounting/system/endpoints/InstallationEndpoint.java
@@ -1261,6 +1261,5 @@ public class InstallationEndpoint {
         public void setContent(List<MetricProjection> content) {
             this.content = content;
         }
-
     }
 }


### PR DESCRIPTION
We cache ~/.m2 between Pipeline runs utilizing the maven container, thereby avoiding the need to re-download
dependencies for subsequent runs of the Pipeline