### PR TITLE
Fix md files to match with mdl 0.11.0 (SQAaaS version)

### DIFF
--- a/website/docs/api/metric_definition.md
+++ b/website/docs/api/metric_definition.md
@@ -130,7 +130,7 @@ PATCH /accounting-system/metric-definitions/{metric_definition_id}
 Content-type: application/json
 Authorization: Bearer {token}
 
-{  
+{
     "metric_type": "metric_type_to_be_updated"
 }
 ```

--- a/website/docs/api/metric_type.md
+++ b/website/docs/api/metric_type.md
@@ -126,7 +126,7 @@ PATCH /accounting-system/metric-types/{metric_type_id}
 Content-type: application/json
 Authorization: Bearer {token}
 
-{  
+{
     "metric_type": "metric_type_to_be_updated"
 }
 ```

--- a/website/docs/api/unit_type.md
+++ b/website/docs/api/unit_type.md
@@ -126,7 +126,7 @@ PATCH /accounting-system/unit-types/{unit_type_id}
 Content-type: application/json
 Authorization: Bearer {token}
 
-{  
+{
     "unit_type": "unit_type_to_be_updated"
 }
 ```

--- a/website/docs/guides/api_actions/installations.md
+++ b/website/docs/guides/api_actions/installations.md
@@ -15,13 +15,15 @@ Installations, this guide outlines all the options available to you.
 
 You can manage an Installation assigned to a specific Project and Provider.
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** [Contact](/docs/authorization/assigning_roles.md) the administrator of
    the Project or the administrator of the
    Project's Provider that this Installation is associated with to assign you
    one or more roles on the Installation.
 
-**NOTE**  
+### NOTE
+
 In the Accounting Service, the **installation_admin** role is the main role
 for managing an Installation. This role permits the user to perform any
 operation on a specific Installation. If the user is assigned any other role,

--- a/website/docs/guides/api_actions/metrics.md
+++ b/website/docs/guides/api_actions/metrics.md
@@ -59,9 +59,10 @@ the Accounting Service API.
 that match one or more criteria. You can define search criteria on each field
 of the **[Metrics Collection](https://argoeu.github.io/argo-accounting/docs/api/metric)**
 or a combination of search criteria on more than one field. You can search
-for Metrics by Metric Definition id, value, period, or a combination of them.  
+for Metrics by Metric Definition id, value, period, or a combination of them.
+
 Apply a request to the Accounting Service API. You need to provide the search
-criteria in a specific  
+criteria in a specific
 **[syntax](https://argoeu.github.io/argo-accounting/docs/guides/search-filter)**
 .
 

--- a/website/docs/guides/api_actions/projects.md
+++ b/website/docs/guides/api_actions/projects.md
@@ -12,11 +12,13 @@ via this guide you can see all the options you have.
 
 ## Before you start
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** [Contact](/docs/authorization/assigning_roles.md) the system
 administrator to assign you one or more roles on the Project.
 
-**NOTE**  
+### NOTE
+
 In the Accounting Service, the **_project_admin_** role is the main role
 for managing a Project. This role permits the user to perform any operation
 on a specific Project. In case the user is assigned any other role, they can
@@ -87,7 +89,8 @@ search criteria on each field of the
 **[Project Collection](https://argoeu.github.io/argo-accounting/docs/api/project)**
 or a combination of search criteria on more than one field. You can search
 by Project's acronym, title, period, call identifier, or a combination of
-them.  
+them.
+
 Apply a request to the Accounting Service API. You need to provide the search
 criteria in a specific
 **[syntax](https://argoeu.github.io/argo-accounting/docs/guides/search-filter)**

--- a/website/docs/guides/api_actions/providers.md
+++ b/website/docs/guides/api_actions/providers.md
@@ -15,12 +15,14 @@ options you have.
 
 You can manage a Provider assigned to a specific Project.
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** [Contact](/docs/authorization/assigning_roles.md) the administrator of
 the Project that this Provider is
 associated with to assign you one or more roles on the Provider.
 
-**NOTE**  
+### NOTE
+
 In the Accounting Service, the **_provider_admin_** role is the main role for
 managing a Provider. This role permits the user to perform any operation on a
 specific Provider. In case the user is assigned any other role, they can
@@ -33,7 +35,7 @@ operate according to the role's permissions.
 ### GET Provider's details
 
 You can get the details of the Provider. Apply a request to the
-Accounting Service API.  
+Accounting Service API.
 
 > 📝 **For more details on how to syntax the request, see** [here](https://argoeu.github.io/argo-accounting/docs/api/provider#get---fetch-an-existing-provider).
 
@@ -43,9 +45,10 @@ You can provide users with access roles on the Provider.
 
 **1.** Read registered clients (see
 [here](https://argoeu.github.io/argo-accounting/docs/api/client#get---read-the-registered-clients)
-) and retrieve the client's id.  
+) and retrieve the client's id.
+
 **2.** Decide on one or more roles that this user will be assigned with on
-the Provider and apply a request to the Accounting Service API.  
+the Provider and apply a request to the Accounting Service API.
 
 > 📝 **For more details on how to syntax the request, see**
 [here](https://argoeu.github.io/argo-accounting/docs/api/provider#post---access-control-entry-for-a-particular-provider-of-a-specific-project)
@@ -54,7 +57,7 @@ the Provider and apply a request to the Accounting Service API.
 ### ASSIGN Installations to the Provider
 
 You can assign one or more Installations to the Provider.
-Apply a request to the Accounting Service API.  
+Apply a request to the Accounting Service API.
 
 > 📝 **For more details on how to syntax the request, see**
 [here](https://argoeu.github.io/argo-accounting/docs/api/installation#post---create-a-new-installation)
@@ -63,7 +66,7 @@ Apply a request to the Accounting Service API.
 ### FETCH all Installations assigned to the provider
 
 You can fetch all Installations assigned to the Provider.
-Apply a request to the Accounting Service API.  
+Apply a request to the Accounting Service API.
 
 > 📝 **For more details on how to syntax the request, see**
 [here](https://argoeu.github.io/argo-accounting/docs/api/installation#get-fetch-all-provider-installations)
@@ -76,9 +79,10 @@ Provider that match one or more criteria. You can define search criteria
 on each field of the **[Installation Collection](https://argoeu.github.io/argo-accounting/docs/api/installation)**
 or a combination of search criteria on more than one field. You can search
 for Installations by Project, Provider, infrastructure, Installation's name,
-Metric Definition id, or a combination of them.  
+Metric Definition id, or a combination of them.
+
 Apply a request to the Accounting Service API. You need to provide the search
-criteria in a specific  
+criteria in a specific
 **[syntax](https://argoeu.github.io/argo-accounting/docs/guides/search-filter)**
 .
 

--- a/website/docs/guides/api_actions/search_filter.md
+++ b/website/docs/guides/api_actions/search_filter.md
@@ -15,7 +15,7 @@ them.
 
 Defining search criteria can be done in two ways:
 
-1. **"query"**: Defines a search on a single field of the collection.  
+1. **"query"**: Defines a search on a single field of the collection.
    E.g., in Collection Metrics: `installation="insta1"`
 
 1. **"filter"**: Defines a search on multiple criteria combined with AND/OR
@@ -63,7 +63,7 @@ of the query should be:
   "type":"query",
   "field": "time_period_start" ,
   "values":"2022-01-01T00:00:00Z",
-  "operand": "gt"  
+  "operand": "gt"
 }
 
 ```
@@ -114,7 +114,7 @@ Query on start period:
   "type":"query",
   "field": "time_period_start" ,
   "values":"2022-01-01T00:00:00Z",
-  "operand": "gt"  
+  "operand": "gt"
 }
 
 ```
@@ -127,7 +127,7 @@ Query on end period:
   "type":"query",
   "field": "time_period_end" ,
   "values":"2022-01-02T00:00:00Z",
-  "operand": "lt"  
+  "operand": "lt"
 }
 
 ```
@@ -172,7 +172,7 @@ The query to search for value greater than 1000 is defined as:
   "type":"query",
   "field": "value" ,
   "values":"1000.0",
-  "operand": "gt"  
+  "operand": "gt"
 }
 ```
 

--- a/website/docs/guides/installation_admin.md
+++ b/website/docs/guides/installation_admin.md
@@ -10,7 +10,8 @@ sidebar_position: 5
 
 You can manage a Provider assigned to a specific Project.
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** Contact the administrator of the Project or the administrator of the
 Project's Provider, that this Installation is associated with, to assign you
 the Installation Admin role upon the installation you want.

--- a/website/docs/guides/project_admin.md
+++ b/website/docs/guides/project_admin.md
@@ -8,7 +8,8 @@ sidebar_position: 3
 
 ## Before you start
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** [Contact](/docs/authorization/assigning_roles.md) the system
 administrator, to assign you the Project Admin role upon the project
 you want.

--- a/website/docs/guides/provider_admin.md
+++ b/website/docs/guides/provider_admin.md
@@ -10,7 +10,8 @@ sidebar_position: 4
 
 You can manage a Provider assigned to a specific Project.
 
-**1.** [Register](/docs/guides/register.md) to Accounting Service.  
+**1.** [Register](/docs/guides/register.md) to Accounting Service.
+
 **2.** Contact the administrator of the Project, that this Provider is
 associated with, to assign you the Provider Admin role upon the provider
 you want.

--- a/website/docs/guides/register.md
+++ b/website/docs/guides/register.md
@@ -14,12 +14,14 @@ There are two ways to register yourself into Accounting Service:
 
 ---
 
-- **Authenticate yourself**  
+- **Authenticate yourself**
+
   First, you need to authenticate yourself to EOSC Core Infrastructure Proxy.
   Instructions are provided [here](https://argoeu.github.io/argo-accounting/docs/authentication/authenticating_clients)
 . Once you gain an access token, copy it.
 
-- **Register yourself**  
+- **Register yourself**
+
   Then, you need to apply a request to the Accounting Service API in order to
   register yourself. For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/client#post---client-registration)
   .
@@ -44,7 +46,8 @@ Once you register for the Accounting Service, you can perform the following acti
 - **HTTP Request**
 
   All users with roles can display all the Metric Definitions existing in the
-  Accounting Service. Apply a request to the API.  
+  Accounting Service. Apply a request to the API.
+
   > 📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/metric_definition#get----fetch-all-metric-definitions).
 
 ### READ Providers
@@ -58,7 +61,8 @@ Once you register for the Accounting Service, you can perform the following acti
 - **HTTP Request**
 
   You can read the Providers available on the EOSC Resource Catalogue and those
-  registered through the Accounting Service API. Apply a request to the API.  
+  registered through the Accounting Service API. Apply a request to the API.
+
   > 📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/provider#get---fetch-all-registered-providers).
 
 ### READ Unit Types
@@ -72,8 +76,9 @@ Once you register for the Accounting Service, you can perform the following acti
 - **HTTP Request**
 
   You can read all the Unit Types registered to the Accounting Service.
-  Apply a request to the API.  
-  >📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/unit_type#get----fetch-all-the-unit-types).
+  Apply a request to the API.
+
+  > 📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/unit_type#get----fetch-all-the-unit-types).
 
 ### READ Metric Types
 
@@ -86,7 +91,8 @@ Once you register for the Accounting Service, you can perform the following acti
 - **HTTP Request**
 
   You can read all the Metric Types registered to the Accounting Service.
-  Apply a request to the API.  
+  Apply a request to the API.
+
   > 📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/metric_type#get----fetch-all-the-metric-types).
 
 ### READ all Clients
@@ -100,7 +106,8 @@ Once you register for the Accounting Service, you can perform the following acti
 - **HTTP Request**
 
   You can read all the Clients registered to the Accounting Service.
-  Apply a request to the API.  
+  Apply a request to the API.
+
   > 📝 For more details on how to syntax the request, see [here](https://argoeu.github.io/argo-accounting/docs/api/client#get---read-the-registered-clients).
 
 ---


### PR DESCRIPTION
The SQAaaS operates mdl 0.11.0 which does not accept certain rules/aspects as of 0.13.0. For instance, double space at the end it's a new line for 0.13.0 so it's correct, while it is considered trailing spaces for 0.11.0. We are backward compatible now.